### PR TITLE
Fix compiling type declarations of vector type arguments in Lisp backend.

### DIFF
--- a/src/lang/compiler/lisp/compile.lisp
+++ b/src/lang/compiler/lisp/compile.lisp
@@ -52,18 +52,34 @@
          (fenv1 (if rec-p
                     (extend-funenv name name1 ftype args fenv)
                     fenv)))
-    (let ((args1 (loop for arg in args
-                    append (query-varenv arg venv1)))
-          (types1 (loop for type in (function-arg-types ftype)
-                     collect (compile-type type)))
-          (body1 (compile-form body venv1 tenv1 aenv fenv1)))
+    (let* ((args1 (loop for arg in args
+                     append (query-varenv arg venv1)))
+           (arg-types (function-arg-types ftype))
+           (arg-types1 (compile-arg-types args arg-types venv1))
+           (body1 (compile-form body venv1 tenv1 aenv fenv1)))
       (values name1 args1
               `((declare (optimize (speed 3) (safety 0)))
                 (declare (ignorable ,@args1))
-                ,@(loop for arg1 in args1
-                        for type1 in types1
-                     collect `(declare (type ,type1 ,arg1)))
+                ,@(loop for (arg1 . type1) in arg-types1
+                     collect `(declare (type ,type1 ,@arg1)))
                 ,body1)))))
+
+(defun compile-arg-types (args types venv)
+  (loop for arg in args
+        for type in types
+     collect
+       (let ((vars (query-varenv arg venv)))
+         (cond
+           ;; Scalar type and array type.
+           ((or (scalar-type-p type)
+                (array-type-p type))
+            (let ((type1 (compile-type type)))
+              (cons vars type1)))
+           ;; Vector type.
+           ((vector-type-p type)
+            (let ((type1 (compile-type (vector-type-base-type type))))
+              (cons vars type1)))
+           (t (error "Must not be reached."))))))
 
 (defun compile-name (name entry-p)
   (if entry-p

--- a/t/lang/compiler/lisp/compile.lisp
+++ b/t/lang/compiler/lisp/compile.lisp
@@ -24,12 +24,37 @@
          (,aenv (empty-appenv))
          (,fenv (empty-funenv))
          (,venv (empty-varenv))
-         (*genvar-counter* 0))
+         (*genvar-counter* 0)
+         (*genname-counter* 0))
      ,@body))
 
 (setf (fdefinition 'compile-form)
       #'avm.lang.compiler.lisp.compile::compile-form)
 
+
+(subtest "compile-function"
+
+  (with-env (tenv aenv fenv venv)
+    (let ((aenv1 (extend-appenv '#1=(+ x y)
+                                '((:vector int 3) (:vector int 3)
+                                  (:vector int 3))
+                                aenv)))
+      (is-values (compile-function 'foo
+                                   '((:vector int 3) (:vector int 3) int)
+                                   '(x y)
+                                   '#1#    ; (+ x y)
+                                   venv tenv aenv1 fenv)
+                 '(foo0 (x0 x1 x2 y3 y4 y5)
+                   ((declare (optimize (speed 3) (safety 0)))
+                    (declare (ignorable x0 x1 x2))
+                    (declare (ignorable y3 y4 y5))
+                    (declare (type fixnum x0 x1 x2))
+                    (declare (type fixnum y3 y4 y5))
+                    (the (values fixnum fixnum fixnum)
+                     (avm.lang.data:int3-add*
+                      (avm.lang.data:int3-values* x0 x1 x2)
+                      (avm.lang.data:int3-values* y3 y4 y5)))))
+                 "Vector type arguments."))))
 
 (subtest "LET"
 


### PR DESCRIPTION
This PR fixes compiling type declarations of vector type arguments in Lisp backend.

Kernel function's vector type arguments are destructured to their elements in Lisp backend so their type declarations should be also for each element of them. For example, an argument `x` of type `int3` should have the following type declaration:

```
(defkernel foo (x)
  ...)

(defun foo (x1 x2 x3)
  (declare (type fixnum x1 x2 x3))
  ...)
```

But currently it is compiled to have a type declaration below with VALUES type for only an element of `x`, it causes a compile error in CL.

```
(defun foo (x1 x2 x3)
  (declare (type (values fixnum fixnum fixnum) x1))
  ...)
```

This PR fixes this problem.
